### PR TITLE
feat: add force_color method for getting FORCE_COLOR env var

### DIFF
--- a/src/colors.rs
+++ b/src/colors.rs
@@ -153,6 +153,11 @@ pub fn use_color() -> bool {
   USE_COLOR.load(std::sync::atomic::Ordering::Relaxed)
 }
 
+/// Whether the `FORCE_COLOR` environment variable is set
+pub fn force_color() -> bool {
+  *FORCE_COLOR
+}
+
 /// Sets whether color should be used in the output.
 ///
 /// This overrides the default values set via the `FORCE_COLOR` and `NO_COLOR` env vars.


### PR DESCRIPTION
We need to read FORCE_COLOR directly from CLI in order to determine behavior